### PR TITLE
No need of Source0

### DIFF
--- a/src/cmdlinetest/test_moto_spec.t
+++ b/src/cmdlinetest/test_moto_spec.t
@@ -21,7 +21,6 @@
   Summary:       A library that allows your python tests to easily mock out the boto library (EXPERIMENTAL SNAKEPIT STANDALONE)
   Group:         Development/Tools
   License:       Apache
-  Source0:       %{name}-%{version}.tar.gz
   BuildRoot:     %{_tmppath}/%{name}-%{version}-root
   BuildRequires: /bin/bash wget make-opt-writable
   AutoReqProv:   no

--- a/src/main/python/snakepit/TEMPLATE.spec
+++ b/src/main/python/snakepit/TEMPLATE.spec
@@ -10,7 +10,6 @@ Release:       {{ build }}
 Summary:       {{ pypi_package_summary }} (EXPERIMENTAL SNAKEPIT STANDALONE)
 Group:         Development/Tools
 License:       {{ pypi_package_licence }}
-Source0:       %{name}-%{version}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-root
 BuildRequires: /bin/bash wget make-opt-writable
 AutoReqProv:   no


### PR DESCRIPTION
There is no need to build a dummy source tar.gz. 
- rpmbuild can build RPMs without it
- actually svn2rpm would pack only the snakepit.yaml. This makes no sense at all.
