### PR TITLE
Build the binary RPM in userspace without opt-permission-mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,32 @@ To install, do:
 $ pip install snakepit
 ```
 
+## Example based on [gaius](https://github.com/ImmobilienScout24/gaius)
+
+In your homedir (on a SL6 server):
+```
+~ $ git clone https://github.com/ImmobilienScout24/gaius.git
+~ $ virtualenv .venv
+~ $ . .venv/bin/activate
+(.venv) ~ $ pip install pip -U
+(.venv) ~ $ pip install snakepit
+(.venv) ~ $ snakepit gaius/snakepit/gaius.yaml
+(.venv) ~ $ deactivate
+~ $ rpmbuild -bb gaius.spec
+~ $ ls  rpmbuild/RPMS/x86_64
+gaius-49.0-0_miniconda_3.9.1.x86_64.rpm
+```
+Some other SL6 Server:
+```
+~ $ sudo rpm -i gaius-49.0-0_miniconda_3.9.1.x86_64.rpm
+~ $ gaius
+Usage:
+    gaius --stack STACK --parameters PARAMETERS --topic-arn ARN [--region REGION]
+```
+
+
+
+
 ## Development
 
 Use pybuilder: http://pybuilder.github.io/

--- a/src/cmdlinetest/test_moto_spec.t
+++ b/src/cmdlinetest/test_moto_spec.t
@@ -21,7 +21,6 @@
   Summary:       A library that allows your python tests to easily mock out the boto library (EXPERIMENTAL SNAKEPIT STANDALONE)
   Group:         Development/Tools
   License:       Apache
-  Source0:       %{name}-%{version}.tar.gz
   BuildRoot:     %{_tmppath}/%{name}-%{version}-root
   BuildRequires: /bin/bash wget make-opt-writable
   AutoReqProv:   no

--- a/src/main/python/snakepit/TEMPLATE.spec
+++ b/src/main/python/snakepit/TEMPLATE.spec
@@ -10,7 +10,6 @@ Release:       {{ build }}
 Summary:       {{ pypi_package_summary }} (EXPERIMENTAL SNAKEPIT STANDALONE)
 Group:         Development/Tools
 License:       {{ pypi_package_licence }}
-Source0:       %{name}-%{version}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-root
 BuildRequires: /bin/bash wget make-opt-writable
 AutoReqProv:   no


### PR DESCRIPTION
This change make it possible to build the desired RPM in userspace without the opt permission hack.
Tested in userhome. 
A possible (tested) way to build:
1. from snakepit.yaml build spec file
2. rpmbuild -bb <spec-file> or rpmbuild -bb <spec-file> --define="_topdir $(pwd)/rpmbuild" to build in a custom direcotry

Thats it!
