### PR TITLE
add the distribution to the yaml spec

### DIFF
--- a/src/main/python/snakepit/main.py
+++ b/src/main/python/snakepit/main.py
@@ -43,6 +43,7 @@ DEFAULTS = {
     'setuptools':                   'setuptools-18.8.1.tar.gz',
     'pip':                          'pip-7.1.2.tar.gz',
     'interpreter':                  'python',
+    'distribution':                 'miniconda',
 }
 
 PYPIMETAMAPPINGS = {
@@ -87,7 +88,8 @@ def custom_output_filename(filename, output_directory):
     return osp.join(output_directory, filename)
 
 
-def build_template(distribution, yaml_spec):
+def build_template(yaml_spec):
+    distribution = yaml_spec['distribution']
     if distribution == "miniconda":
         template_filename = 'TEMPLATE-miniconda.spec'
     elif distribution == "pyrun":
@@ -106,9 +108,10 @@ def build_template(distribution, yaml_spec):
     return template.render(**yaml_spec)
 
 
-def construct_build_number(distribution, build, yaml_spec):
+def construct_build_number(build, yaml_spec):
     # create the build number
     yaml_spec['build'] = build
+    distribution = yaml_spec['distribution']
     if distribution == "miniconda":
         build_number = "{0}_{1}{2}_{3}".format(
             yaml_spec['build'],
@@ -150,13 +153,14 @@ def main(arguments):
     # do some more magic
     add_conda_dist_flavour_prefix(yaml_spec)
 
-    # build release number
-    construct_build_number(arguments['--distribution'],
-                           arguments['--build'],
-                           yaml_spec)
+    # update the distribution with a value from the command-line
+    if arguments['--distribution']:
+        yaml_spec['distribution'] = arguments['--distribution']
 
-    rendered_template = build_template(arguments['--distribution'],
-                                       yaml_spec)
+    # build release number
+    construct_build_number(arguments['--build'], yaml_spec)
+
+    rendered_template = build_template(yaml_spec)
 
     # get the output filename
     if arguments['--output']:


### PR DESCRIPTION
This change allows you to specify the distribution in the yaml spec file:

```
pypi_package_name:    moto

pypi_package_version: 0.3.1

symlinks:             ['moto_server']

distribution:         pyrun
```

This is better than using --distribution on the command-line, because more
information about the package and how it was built is inside the yaml spec. In
fact, i'd like to remove the '--distribution' switch entirely unless there is
aneed for it.

The only reason '--build' exists is so that we can inject the build-number from
the CI system at build-time. Everything else _should_ be known in advance.
